### PR TITLE
Sentryfile/hash support addition

### DIFF
--- a/foxedbot.js/app.js
+++ b/foxedbot.js/app.js
@@ -80,7 +80,7 @@ if (fs.existsSync(Config.sentryfile)) {
 };
 
 /* SteamBot */
-if(sentry) {
+if (sentry) {
 	app.bot.logOn({
 		accountName: accname,
 		password: pass,
@@ -112,7 +112,7 @@ app.bot.on("error", function (e) {
 
 			setTimeout(function () {
 				app.logger.info("Reconnecting to Steam...");
-				if(sentry) {
+				if (sentry) {
 					app.bot.logOn({
 						accountName: accname,
 						password: pass,
@@ -208,8 +208,8 @@ app.bot.on("friend", function (steamID, status) {
 
 app.bot.on('sentry', function(buffer) {
 	app.logger.info("Received sentry event");
-	fs.writeFile(Config.sentryfile, bugger, function(err) {
-		if(err){
+	fs.writeFile(Config.sentryfile, buffer, function(err) {
+		if (err) {
 			app.logger.info("Failed to save sentry hash: " + err);
 		} else {
 			app.logger.info("Successfully saved sentry hash.");

--- a/foxedbot.js/config/settings.js.default
+++ b/foxedbot.js/config/settings.js.default
@@ -9,7 +9,7 @@ module.exports = {
 	/* Steam Guard code: set to 'authCode: null,' once the bot is verified or if you don't use SteamGuard */
 	authCode: "<SteamGuardCode>",
 	/* Enter location for ShaSentryFile */
-	sentryfile: "<SentryFileLocation>",
+	sentryfile: "./config/shasentry.bin",
 
 	/* The ServerKey of the SteamBot */
 	serverKey: "ChangeMe!",

--- a/foxedbot.js/config/settings.js.default
+++ b/foxedbot.js/config/settings.js.default
@@ -8,7 +8,8 @@ module.exports = {
 
 	/* Steam Guard code: set to 'authCode: null,' once the bot is verified or if you don't use SteamGuard */
 	authCode: "<SteamGuardCode>",
-
+	/* Enter location for ShaSentryFile */
+	sentryfile: "<SentryFileLocation>",
 
 	/* The ServerKey of the SteamBot */
 	serverKey: "ChangeMe!",

--- a/foxedbot.js/config/settings.js.default
+++ b/foxedbot.js/config/settings.js.default
@@ -8,6 +8,7 @@ module.exports = {
 
 	/* Steam Guard code: set to 'authCode: null,' once the bot is verified or if you don't use SteamGuard */
 	authCode: "<SteamGuardCode>",
+
 	/* Enter location for ShaSentryFile */
 	sentryfile: "./config/shasentry.bin",
 


### PR DESCRIPTION
This would quite quickly and easily add support for the use of the sentry-hash via the node-steam modules.
This will make it easier to verify a server to be able to log onto it's bot account without having to re-do the steam auth-code every single time.

The setting in settings.js defines location of a sentryfile. If SteamGuard is used on the account logged in, and an authcode was used, then it will automatically create a file in that location. If you already have a sentryfile it will read it and use the hash. In that case the authcode becomes redundant, because a sentryhash does not expire, where an authcode will expire after a certain time.
